### PR TITLE
Resolve Windows-Specific Path Duplication in a_person_mask_generator Script

### DIFF
--- a/scripts/a_person_mask_generator.py
+++ b/scripts/a_person_mask_generator.py
@@ -53,10 +53,13 @@ class Script(scripts.Script):
 
     def generate_mask(self, image: Image, mask_targets: list[str], mask_dilation : int) -> Image:
         if image is not None and len(mask_targets) > 0:
-            model_folder_path = os.path.join(models_path, 'mediapipe')
+            model_folder_name = 'mediapipe'
+            model_file_name = 'selfie_multiclass_256x256.tflite'
+            model_folder_path = os.path.join(models_path, model_folder_name) if not models_path.endswith(model_folder_name) else models_path
             os.makedirs(model_folder_path, exist_ok=True)
+        
 
-            model_path = os.path.join(model_folder_path, 'selfie_multiclass_256x256.tflite')
+            model_path = os.path.join(model_folder_path, model_file_name)
             model_url = 'https://storage.googleapis.com/mediapipe-models/image_segmenter/selfie_multiclass_256x256/float32/latest/selfie_multiclass_256x256.tflite'
             if not os.path.exists(model_path):
                 print(f"Downloading 'selfie_multiclass_256x256.tflite' model")


### PR DESCRIPTION
### Description

This pull request addresses a Windows-specific path duplication issue in the `a_person_mask_generator.py` script. On Windows, the script incorrectly constructs the model file path by appending the base directory twice, resulting in a runtime error when attempting to initialize the MediaPipe ImageSegmenter.

### Changes Made

- Implemented a conditional check to prevent appending 'mediapipe' to `models_path` if it already ends with 'mediapipe', ensuring compatibility with Windows file paths.
- Adjusted the construction of `model_path` to concatenate the model file name without duplicating the base directory path, specifically addressing Windows path concatenation behavior.

### How to Test

1. On a Windows system, set up and run the process that utilizes the `a_person_mask_generator` script within the Stable Diffusion web UI.
2. Verify that the script executes without encountering the previous runtime error related to path duplication.

### Issue Fixed

This fix resolves a Windows-specific runtime error caused by incorrect path construction in the `a_person_mask_generator.py` script, enhancing the script's compatibility and reliability on Windows platforms.
