### PR TITLE
fixed install.py for ComfyUI

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,14 +1,10 @@
-import launch
+import sys
 import os
+import subprocess
 
 req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
 
 with open(req_file) as file:
     for package in file:
-        try:
-            package = package.strip()
-            if not launch.is_installed(package):
-                launch.run_pip(f"install {package}", f"a-person-mask-generator requirement: {package}")
-        except Exception as e:
-            print(e)
-            print(f'a-person-mask-generator: Warning: Failed to install {package}.')
+        package = package.strip()
+        subprocess.check_call([sys.executable, "-m", "pip", "install", package])


### PR DESCRIPTION
`import launch` does not work due to the decracation which used to install missing libraries. In order to fix this problem for **ComfyUI**, I've changed the missing library installation process with `subprocess` and `sys `libraries which are built-in libraries from Python. 

PS : Tests are passed on local PC.